### PR TITLE
Update for compatability with the dart dev compiler

### DIFF
--- a/lib/src/diff/diff.dart
+++ b/lib/src/diff/diff.dart
@@ -68,11 +68,12 @@ class Diff {
   /**
    * Is this Diff equivalent to another Diff?
    *
-   * [other] is another Diff to compare against.
+   * [other] is another object to compare against.
    *
-   * Returns true or false.
+   * Returns true or false based on whether [other] is a Diff with the same [operation]
+   * and [text] values as this Diff.
    */
-  bool operator ==(Diff other) {
-    return (operation == other.operation && text == other.text);
+  bool operator ==(other) {
+    return other is Diff && operation == other.operation && text == other.text;
   }
 }


### PR DESCRIPTION
### Problem

I'm using this package in a project that we're keeping compatible with the ddc. The `==` implementation caused a compilation error.

### Solution

Update the type signature to prevent the following error:

`error: Invalid override. The type of 'Diff.==' ('(Diff) → bool') isn't a subtype of 'Object.==' ('(dynamic) → bool'). (strong_mode_invalid_method_override at [diff_match_patch] lib/src/diff/diff.dart:75)`